### PR TITLE
Updated openssl to 1.0.1k

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -20,9 +20,9 @@ dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix?
 
-default_version "1.0.1j"
-source url: "http://www.openssl.org/source/openssl-1.0.1j.tar.gz",
-       md5: "f7175c9cd3c39bb1907ac8bba9df8ed3"
+default_version "1.0.1k"
+source url: "http://www.openssl.org/source/openssl-1.0.1k.tar.gz",
+       md5: "d4f002bd22a56881340105028842ae1f"
 
 relative_path "openssl-#{version}"
 


### PR DESCRIPTION
OpenSSL 1.0.1k was just released, but the *j* version wasn't properly moved to the [old releases repo](https://www.openssl.org/source/old/1.0.1/) as of this writing, making omnibus builds break with

```
(...)
[NetFetcher: openssl] I | Downloading from `http://www.openssl.org/source/openssl-1.0.1j.tar.gz'
[NetFetcher: openssl] E | Download failed - OpenURI::HTTPError!
/opt/rubies/ruby-2.1.5/lib/ruby/2.1.0/open-uri.rb:353:in `open_http': 404 Not Found (OpenURI::HTTPError)
(...)
```